### PR TITLE
Fixed Double Jump

### DIFF
--- a/Content/Enhanced_Input/IA_Jump.uasset
+++ b/Content/Enhanced_Input/IA_Jump.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e15d211b54d8f11b71c047ec1d35531ba904004cb7407fc1ac2c4cf49036213d
+oid sha256:07dc0feb1b78990fc159fad01c3ef5d72b8c3dbd6f194ff27f43366f9d0eb97c
 size 1370

--- a/Source/FightingGame/PlayerPawn.cpp
+++ b/Source/FightingGame/PlayerPawn.cpp
@@ -176,7 +176,7 @@ void APlayerPawn::SetupPlayerInputComponent(UInputComponent* PlayerInputComponen
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Binding Actions"));
 		// Bind jumping actions
-		EnhancedInput->BindAction(IA_Jump, ETriggerEvent::Triggered, this, &APlayerPawn::StartJump);
+		EnhancedInput->BindAction(IA_Jump, ETriggerEvent::Started, this, &APlayerPawn::StartJump);
 		EnhancedInput->BindAction(IA_Jump, ETriggerEvent::Completed, this, &APlayerPawn::StopJump);
 		EnhancedInput->BindAction(Forward_Movement, ETriggerEvent::Triggered, this, &APlayerPawn::MoveForward);
 		EnhancedInput->BindAction(Forward_Movement, ETriggerEvent::Completed, this, &APlayerPawn::StopMoving);
@@ -230,7 +230,8 @@ void APlayerPawn::StopSprint()
 
 void APlayerPawn::StartJump()
 {
-	if (!bIsJumping) // First jump
+	bDidDoubleJump = false; //we don't yet know if there has been a double jump
+	if (GetCharacterMovement()->IsMovingOnGround()) // First jump - check if on the ground
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Jumping from ground"));
 		LaunchCharacter(FVector(0, 0, JumpForce), false, true);
@@ -255,7 +256,7 @@ void APlayerPawn::StartJump()
 			UE_LOG(LogTemp, Warning, TEXT("Action jump perform"));
 			PlayerMesh->PlayAnimation(JumpFromStand, false);
 		}
-		bCanDoubleJump = false; // Only allow one mid-air jump
+		bCanDoubleJump = false;
 	}
 }
 
@@ -269,8 +270,8 @@ void APlayerPawn::StartJump()
 //}
 
 void APlayerPawn::StopJump() {
-	bIsJumping = false;
-	bCanDoubleJump = true; // Restore double jump ability
+	//bIsJumping = false;
+	//bCanDoubleJump = true; // Restore double jump ability
 	if (bIsMoving) PlayerMesh->PlayAnimation(WalkForward, false);
 }
 


### PR DESCRIPTION
If the player is touching the ground and jumps, it must be their first jump. Otherwise, it must be their second jump and bCanDoubleJump is reset to false. I also needed only to call the jump function when the input action has started, not when it has triggered - this means that holding the spacebar down no longer causes you to float upwards.